### PR TITLE
v1.5.03

### DIFF
--- a/Query Builder/CHANGEDB.php
+++ b/Query Builder/CHANGEDB.php
@@ -185,3 +185,9 @@ INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, 
 $sql[$count][0] = '1.5.02';
 $sql[$count][1] = "
 ";
+
+//v1.5.03
+++$count;
+$sql[$count][0] = '1.5.03';
+$sql[$count][1] = "
+";

--- a/Query Builder/CHANGELOG.txt
+++ b/Query Builder/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v1.5.03
+-------
+Add an error message for incorrect SQL syntax
+
 v1.5.02
 -------
 Fix query search issue

--- a/Query Builder/manifest.php
+++ b/Query Builder/manifest.php
@@ -25,7 +25,7 @@ $description = 'A module to provide SQL queries for pulling data out of Gibbon a
 $entryURL = 'queries.php';
 $type = 'Additional';
 $category = 'Admin';
-$version = '1.5.02';
+$version = '1.5.03';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org';
 

--- a/Query Builder/queries_run.php
+++ b/Query Builder/queries_run.php
@@ -156,11 +156,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_run.
                     //Run the query
                     $result = $pdo->select($query);
 
-
-                    if ($result->rowCount() < 1) {
-                        echo "<div class='warning'>Your query has returned 0 rows.</div>";
+                    if (!$pdo->getQuerySuccess()) {
+                        echo '<div class="error">'.__('Your request failed due to a syntax error in the SQL query.').'</div>';
+                    } else if ($result->rowCount() < 1) {
+                        echo '<div class="warning">'.__('Your query has returned 0 rows.').'</div>';
                     } else {
-                        echo "<div class='success'>Your query has returned ".$result->rowCount().' rows, which are displayed below.</div>';
+                        echo '<div class="success">'.sprintf(__('Your query has returned %1$s rows, which are displayed below.'), $result->rowCount()).'</div>';
 
                         echo "<div class='linkTop'>";
 

--- a/Query Builder/version.php
+++ b/Query Builder/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '1.5.02';
+$moduleVersion = '1.5.03';


### PR DESCRIPTION
This PR adds an error message for incorrect SQL syntax. Currently, a failed query will show 0 results, which can be misleading if you don't notice there's an error in the query itself (rather than no actual results).

Before:
<img width="380" alt="screen shot 2018-09-12 at 9 23 31 am" src="https://user-images.githubusercontent.com/897700/45396347-a7573180-b66d-11e8-8e0a-202cc1a37f53.png">

After:
<img width="385" alt="screen shot 2018-09-12 at 9 24 08 am" src="https://user-images.githubusercontent.com/897700/45396345-a3c3aa80-b66d-11e8-98c3-7c08a5cc1993.png">
