### PR TITLE
v1.7.00 

### DIFF
--- a/Query Builder/CHANGEDB.php
+++ b/Query Builder/CHANGEDB.php
@@ -221,3 +221,10 @@ $sql[$count][1] = "
 $sql[$count][0] = '1.6.04';
 $sql[$count][1] = "
 ";
+
+//v1.7.00
+++$count;
+$sql[$count][0] = '1.7.00';
+$sql[$count][1] = "
+ALTER TABLE `queryBuilderQuery` ADD `bindValues` TEXT NULL DEFAULT NULL AFTER `query`;end
+";

--- a/Query Builder/CHANGELOG.txt
+++ b/Query Builder/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v1.7.00
+-------
+Add the ability to use variables in queries
+
 v1.6.04
 -------
 Memory limit increase

--- a/Query Builder/manifest.php
+++ b/Query Builder/manifest.php
@@ -25,7 +25,7 @@ $description = 'A module to provide SQL queries for pulling data out of Gibbon a
 $entryURL = 'queries.php';
 $type = 'Additional';
 $category = 'Admin';
-$version = '1.6.04';
+$version = '1.7.00';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org';
 

--- a/Query Builder/manifest.php
+++ b/Query Builder/manifest.php
@@ -30,7 +30,7 @@ $author = 'Ross Parker';
 $url = 'http://rossparker.org';
 
 //Module tables & gibbonSettings entries
-$moduleTables[0] = "CREATE TABLE `queryBuilderQuery` (`queryBuilderQueryID` int(10) unsigned zerofill NOT NULL AUTO_INCREMENT, `type` enum('gibbonedu.com','Personal','School') NOT NULL DEFAULT 'gibbonedu.com', `name` varchar(255) NOT NULL,  `category` varchar(50) NOT NULL,  `description` text NOT NULL,  `query` text NOT NULL,  `active` enum('Y','N') NOT NULL DEFAULT 'Y',  `queryID` int(10) unsigned zerofill DEFAULT NULL COMMENT 'If based on a gibbonedu.org query.',  `gibbonPersonID` int(10) unsigned zerofill DEFAULT NULL,  PRIMARY KEY (`queryBuilderQueryID`)) ENGINE=InnoDB DEFAULT CHARSET=utf8";
+$moduleTables[0] = "CREATE TABLE `queryBuilderQuery` (`queryBuilderQueryID` int(10) unsigned zerofill NOT NULL AUTO_INCREMENT, `type` enum('gibbonedu.com','Personal','School') NOT NULL DEFAULT 'gibbonedu.com', `name` varchar(255) NOT NULL,  `category` varchar(50) NOT NULL,  `description` text NOT NULL,  `query` text NOT NULL, `bindValues` TEXT NULL DEFAULT NULL, `active` enum('Y','N') NOT NULL DEFAULT 'Y',  `queryID` int(10) unsigned zerofill DEFAULT NULL COMMENT 'If based on a gibbonedu.org query.',  `gibbonPersonID` int(10) unsigned zerofill DEFAULT NULL,  PRIMARY KEY (`queryBuilderQueryID`)) ENGINE=InnoDB DEFAULT CHARSET=utf8";
 
 //gibbonSettings entries
 $gibbonSetting[0] = "INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES ('Query Builder', 'exportDefaultFileType', 'Default Export File Type', '', 'Excel2007');";

--- a/Query Builder/queries_edit.php
+++ b/Query Builder/queries_edit.php
@@ -103,6 +103,42 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_edit
                     ->addClass('thickbox floatRight');
                 $col->addElement($queryEditor)->isRequired();
 
+            
+            // BIND VALUES
+            $types = [
+                'number' => __('Number'),
+                'varchar' => __('Text'),
+                'date' => __('Date'),
+            ];
+            
+            // Custom Block Template
+            $addBlockButton = $form->getFactory()->createButton(__('Add Variable'))->addClass('addBlock');
+
+            $blockTemplate = $form->getFactory()->createTable()->setClass('blank');
+            $row = $blockTemplate->addRow();
+                $row->addTextField('name')
+                    ->setClass('w-2/3 pr-10 title')
+                    ->required()
+                    ->placeholder(__('Name'))
+                    ->addValidation('Validate.Format', 'pattern: /^[A-Za-z0-9]+$/, failureMessage: "'.__m('Alphanumeric values only.').'"');
+            $row = $blockTemplate->addRow();
+                $row->addSelect('type')->fromArray($types)->setClass('w-2/3 float-none mt-1')->required()->placeholder();
+
+            // Custom Blocks
+            $col = $form->addRow()->addColumn();
+                $col->addLabel('bindValues', __m('Variables'))->description(__m('Variables allow...'));
+                $customBlocks = $col->addCustomBlocks('bindValues', $gibbon->session)
+                    ->fromTemplate($blockTemplate)
+                    ->settings(array('inputNameStrategy' => 'object', 'addOnEvent' => 'click', 'sortable' => true))
+                    ->placeholder(__m('Variables will be listed here...'))
+                    ->addToolInput($addBlockButton);
+
+            // Add existing bindValues
+            $bindValues = json_decode($values['bindValues'], true);
+            foreach ($bindValues ?? [] as $index => $bindValue) {
+                $customBlocks->addBlock($index, $bindValue);
+            }
+
             $row = $form->addRow();
                 $row->addFooter();
                 $row->addSubmit();

--- a/Query Builder/queries_editProcess.php
+++ b/Query Builder/queries_editProcess.php
@@ -17,75 +17,65 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Module\QueryBuilder\Domain\QueryGateway;
+
 include '../../gibbon.php';
 
 
-$search = null;
-if (isset($_GET['search'])) {
-    $search = $_GET['search'];
-}
-$queryBuilderQueryID = $_GET['queryBuilderQueryID'];
+$search = $_GET['search'] ?? '';
+$queryBuilderQueryID = $_GET['queryBuilderQueryID'] ?? '';
 $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/queries_edit.php&queryBuilderQueryID='.$queryBuilderQueryID."&sidebar=false&search=$search";
 
 if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_edit.php') == false) {
-    //Fail 0
     $URL = $URL.'&return=error0';
     header("Location: {$URL}");
+    exit;
 } else {
     //Proceed!
-    //Check if school year specified
-    if ($queryBuilderQueryID == '') {
-        //Fail1
-        $URL = $URL.'&return=error1';
+    $queryGateway = $container->get(QueryGateway::class);
+
+    $data = [
+        'name'        => $_POST['name'],
+        'category'    => $_POST['category'],
+        'active'      => $_POST['active'],
+        'description' => $_POST['description'],
+        'query'       => $_POST['query'],
+        'bindValues'  => $_POST['bindValues'],
+    ];
+
+    // Sort and jsonify bindValues
+    $data['bindValues'] = array_combine(array_keys($_POST['order']), array_values($data['bindValues']));
+    ksort($data['bindValues']);
+    $data['bindValues'] = json_encode($data['bindValues']);
+
+    // Validate the required values are present
+    if (empty($queryBuilderQueryID) || empty($data['name']) || empty($data['category']) || empty($data['active']) || empty($data['query'])) {
+        $URL .= '&return=error1';
         header("Location: {$URL}");
-    } else {
-        try {
-            $data = array('queryBuilderQueryID' => $queryBuilderQueryID, 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
-            $sql = "SELECT * FROM queryBuilderQuery WHERE queryBuilderQueryID=:queryBuilderQueryID AND NOT type='gibbonedu.com' AND gibbonPersonID=:gibbonPersonID";
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            //Fail2
-            $URL = $URL.'&deleteReturn=error2';
-            header("Location: {$URL}");
-            exit();
-        }
-
-        if ($result->rowCount() != 1) {
-            //Fail 2
-            $URL = $URL.'&return=error2';
-            header("Location: {$URL}");
-        } else {
-            //Validate Inputs
-            $name = $_POST['name'];
-            $category = $_POST['category'];
-            $active = $_POST['active'];
-            $description = $_POST['description'];
-            $query = $_POST['query'];
-            $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
-
-            if ($name == '' or $category == '' or $active == '' or $query == '') {
-                //Fail 3
-                $URL = $URL.'&return=error3';
-                header("Location: {$URL}");
-            } else {
-                //Write to database
-                try {
-                    $data = array('name' => $name, 'category' => $category, 'active' => $active, 'description' => $description, 'query' => $query, 'queryBuilderQueryID' => $queryBuilderQueryID);
-                    $sql = 'UPDATE queryBuilderQuery SET name=:name, category=:category, active=:active, description=:description, query=:query WHERE queryBuilderQueryID=:queryBuilderQueryID';
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    //Fail 2
-                    $URL = $URL.'&return=error2';
-                    header("Location: {$URL}");
-                    exit();
-                }
-
-                //Success 0
-                $URL = $URL.'&return=success0';
-                header("Location: {$URL}");
-            }
-        }
+        exit;
     }
+
+    // Validate the database relationships exist
+    $values = $queryGateway->getByID($queryBuilderQueryID);
+    if (empty($values)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Validate this user has access to this query
+    if ($values['type'] == 'gibbonedu.com' || ($values['Personal'] && $values['gibbonPersonID'] != $gibbon->session->get('gibbonPersonID'))) {
+        $URL .= '&return=error0';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Update the record
+    $updated = $queryGateway->update($queryBuilderQueryID, $data);
+
+    $URL .= !$updated
+        ? "&return=error2"
+        : "&return=success0";
+
+    header("Location: {$URL}");
 }

--- a/Query Builder/src/Domain/QueryGateway.php
+++ b/Query Builder/src/Domain/QueryGateway.php
@@ -32,6 +32,7 @@ class QueryGateway extends QueryableGateway
     use TableAware;
 
     private static $tableName = 'queryBuilderQuery';
+    private static $primaryKey = 'queryBuilderQueryID';
 
     private static $searchableColumns = ['name', 'category'];
     

--- a/Query Builder/version.php
+++ b/Query Builder/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '1.6.04';
+$moduleVersion = '1.7.00';


### PR DESCRIPTION
This PR adds the ability to use variables in queries. When editing a query, users can optionally define one or more variables with a Label Name, Variable Name and Type. When running the query, this presents users with form fields to enter the values for these variables.

Example: defining variables with a custom-block style interface
<img width="918" alt="Screen Shot 2020-03-27 at 2 16 32 PM" src="https://user-images.githubusercontent.com/897700/77729379-7bc24f00-7039-11ea-983c-5edc9ddc8f76.png">

An alert is displayed if the variable name isn't present in the query
<img width="894" alt="Screen Shot 2020-03-27 at 2 16 49 PM" src="https://user-images.githubusercontent.com/897700/77729411-8f6db580-7039-11ea-85c3-59cf08875cb2.png">

On the Run Query screen users select/enter the necessary values.
<img width="975" alt="Screen Shot 2020-03-27 at 2 17 33 PM" src="https://user-images.githubusercontent.com/897700/77729455-a90efd00-7039-11ea-8be2-b071831eb873.png">

Variables are optional and should have no impact on backwards-compatibility. Tested locally with updating and installing from scratch.

**Edit**: this version of the module will require v20. I made two small changes to the core which can be seen here: https://github.com/GibbonEdu/core/commit/dfa682e52a3253dc90de4045a6d5ffaa99cbea71