### PR TITLE
v1.7.02

### DIFF
--- a/Query Builder/CHANGEDB.php
+++ b/Query Builder/CHANGEDB.php
@@ -233,3 +233,8 @@ ALTER TABLE `queryBuilderQuery` ADD `bindValues` TEXT NULL DEFAULT NULL AFTER `q
 ++$count;
 $sql[$count][0] = '1.7.01';
 $sql[$count][1] = "";
+
+//v1.7.02
+++$count;
+$sql[$count][0] = '1.7.02';
+$sql[$count][1] = "";

--- a/Query Builder/CHANGELOG.txt
+++ b/Query Builder/CHANGELOG.txt
@@ -4,6 +4,7 @@ v1.7.02
 -------
 Add variables to the Add Query page.
 Add variables to gibbonedu.com sync.
+Disable Edit link for gibbonedu.com queries.
 
 v1.7.01
 -------

--- a/Query Builder/CHANGELOG.txt
+++ b/Query Builder/CHANGELOG.txt
@@ -1,5 +1,10 @@
 CHANGELOG
 =========
+v1.7.02
+-------
+Add variables to the Add Query page.
+Add variables to gibbonedu.com sync.
+
 v1.7.01
 -------
 Links from Edit to Run, and Run to Edit.

--- a/Query Builder/manifest.php
+++ b/Query Builder/manifest.php
@@ -25,7 +25,7 @@ $description = 'A module to provide SQL queries for pulling data out of Gibbon a
 $entryURL = 'queries.php';
 $type = 'Additional';
 $category = 'Admin';
-$version = '1.7.01';
+$version = '1.7.02';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org';
 

--- a/Query Builder/queries_add.php
+++ b/Query Builder/queries_add.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Module\QueryBuilder\Forms\QueryEditor;
+use Gibbon\Module\QueryBuilder\Forms\BindValues;
 
 $page->breadcrumbs
   ->add(__('Manage Queries'), 'queries.php')
@@ -87,6 +88,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_add.
             ->setURL($_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/queries_help_full.php&width=1100&height=550')
             ->addClass('thickbox floatRight');
         $col->addElement($queryEditor)->isRequired();
+
+    $bindValues = new BindValues($form->getFactory(), 'bindValues', [], $gibbon->session);
+    $form->addRow()->addElement($bindValues);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/Query Builder/queries_edit.php
+++ b/Query Builder/queries_edit.php
@@ -39,13 +39,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_edit
     $queryBuilderQueryID = isset($_GET['queryBuilderQueryID'])? $_GET['queryBuilderQueryID'] : '';
     $search = isset($_GET['search'])? $_GET['search'] : '';
 
-    echo "<div class='linkTop'>";
-        if ($search != '') {
-            echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Query Builder/queries.php&search=$search'>".__($guid, 'Back to Search Results').'</a> | ';
-        }
-        echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Query Builder/queries_run.php&search=$search&queryBuilderQueryID=$queryBuilderQueryID&sidebar=false'>".__m('Run Query')."</a>" ;
-    echo '</div>';
-
     //Check if school year specified
     if (empty($queryBuilderQueryID)) {
         echo "<div class='error'>";
@@ -68,6 +61,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_edit
         } else {
             //Let's go!
             $values = $result->fetch();
+
+            echo "<div class='linkTop'>";
+            if ($search != '') {
+                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Query Builder/queries.php&search=$search'>".__($guid, 'Back to Search Results').'</a> | ';
+            }
+            if ($values['active'] == 'Y') {
+                echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Query Builder/queries_run.php&search=$search&queryBuilderQueryID=$queryBuilderQueryID&sidebar=false'>".__m('Run Query')."</a>" ;
+            }
+            echo '</div>';
 
             $form = Form::create('queryBuilder', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/queries_editProcess.php?queryBuilderQueryID='.$queryBuilderQueryID.'&search='.$search);
 

--- a/Query Builder/queries_edit.php
+++ b/Query Builder/queries_edit.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Module\QueryBuilder\Forms\QueryEditor;
+use Gibbon\Module\QueryBuilder\Forms\BindValues;
 
 $page->breadcrumbs
   ->add(__('Manage Queries'), 'queries.php')
@@ -106,64 +107,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_edit
                     ->addClass('thickbox floatRight');
                 $col->addElement($queryEditor)->isRequired();
 
-
-            // BIND VALUES
-            $bindValues = json_decode($values['bindValues'] ?? '', true);
-            $types = [
-                __('Basic') => [
-                    'varchar'        => __('Text'),
-                    'number'         => __('Number'),
-                    'yesno'          => __('Yes/No'),
-                    'date'           => __('Date'),
-                ],
-                __('System') => [
-                    'reportingCycle' => __('Reporting Cycle'),
-                    'schoolYear'     => __('School Year'),
-                    'term'           => __('Term'),
-                ],
-            ];
-
-            $missingValues = array_filter($bindValues ?? [], function ($bindValue) use ($values) {
-                return strpos($values['query'], ':'.$bindValue['variable']) === false;
-            });
-
-            // Custom Block Template
-            $addBlockButton = $form->getFactory()->createButton(__('Add Value'))->addClass('addBlock');
-
-            $blockTemplate = $form->getFactory()->createTable()->setClass('blank');
-            $row = $blockTemplate->addRow();
-                $row->addTextField('name')
-                    ->setClass('w-full m-0 title')
-                    ->required()
-                    ->placeholder(__m('Label Name'));
-
-            $col = $blockTemplate->addRow()->addColumn()->addClass('flex mt-1');
-                $col->addTextField('variable')
-                    ->setClass('w-64')
-                    ->required()
-                    ->placeholder(__m('Variable Name'))
-                    ->addValidation('Validate.Format', 'pattern: /^[A-Za-z0-9]+$/, failureMessage: "'.__m('Must be alphanumeric.').'"');
-                $col->addSelect('type')->fromArray($types)->setClass('w-full float-none ml-1')->required()->placeholder();
-
-            // Custom Blocks
-            $col = $form->addRow()->addColumn();
-                $col->addLabel('bindValues', __m('Variables'));
-                $col->addContent(__m('You can optionally define named variables that a user can enter when running this query. Each variable name must be alphanumeric with no spaces or special symbols, and must be present in the query as :variableName'))->wrap('<span class="small emphasis">', '</span>');
-
-                if (!empty($missingValues)) {
-                    $col->addAlert(__m('SQL Error! The following variable names were not found in your query: {variables}', ['variables' => implode(', ', array_column($missingValues, 'variable'))]), 'error');
-                }
-
-                $customBlocks = $col->addCustomBlocks('bindValues', $gibbon->session)
-                    ->fromTemplate($blockTemplate)
-                    ->settings(array('inputNameStrategy' => 'object', 'addOnEvent' => 'click', 'sortable' => true))
-                    ->placeholder(__m('Variables will be listed here...'))
-                    ->addToolInput($addBlockButton);
-
-            // Add existing bindValues
-            foreach ($bindValues ?? [] as $index => $bindValue) {
-                $customBlocks->addBlock($index, $bindValue);
-            }
+            $bindValues = new BindValues($form->getFactory(), 'bindValues', $values, $gibbon->session);
+            $form->addRow()->addElement($bindValues);
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/Query Builder/queries_editProcess.php
+++ b/Query Builder/queries_editProcess.php
@@ -35,12 +35,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_edit
     $queryGateway = $container->get(QueryGateway::class);
 
     $data = [
-        'name'        => $_POST['name'],
-        'category'    => $_POST['category'],
-        'active'      => $_POST['active'],
-        'description' => $_POST['description'],
-        'query'       => $_POST['query'],
-        'bindValues'  => $_POST['bindValues'],
+        'name'        => $_POST['name'] ?? '',
+        'category'    => $_POST['category'] ?? '',
+        'active'      => $_POST['active'] ?? 'Y',
+        'description' => $_POST['description'] ?? '',
+        'query'       => $_POST['query'] ?? '',
+        'bindValues'  => $_POST['bindValues'] ?? [],
     ];
 
     // Sort and jsonify bindValues

--- a/Query Builder/queries_gibboneducom_sync_ajax.php
+++ b/Query Builder/queries_gibboneducom_sync_ajax.php
@@ -44,8 +44,8 @@ if (count($queries) < 1) { //We have a problem, report it.
     //Now let's get them in
     for ($i = 0; $i < count($queries); ++$i) {
         try {
-            $data = array('queryID' => $queries[$i]['queryID'], 'name' => $queries[$i]['name'], 'category' => $queries[$i]['category'], 'description' => $queries[$i]['description'], 'query' => $queries[$i]['query']);
-            $sql = "INSERT INTO queryBuilderQuery SET type='gibbonedu.com', queryID=:queryID, name=:name, category=:category, description=:description, query=:query";
+            $data = array('queryID' => $queries[$i]['queryID'], 'name' => $queries[$i]['name'], 'category' => $queries[$i]['category'], 'description' => $queries[$i]['description'], 'query' => $queries[$i]['query'], 'bindValues' => $queries[$i]['bindValues'] ?? '');
+            $sql = "INSERT INTO queryBuilderQuery SET type='gibbonedu.com', queryID=:queryID, name=:name, category=:category, description=:description, query=:query, bindValues=:bindValues";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {

--- a/Query Builder/queries_run.php
+++ b/Query Builder/queries_run.php
@@ -43,13 +43,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_run.
     $queryBuilderQueryID = isset($_GET['queryBuilderQueryID'])? $_GET['queryBuilderQueryID'] : '';
     $search = isset($_GET['search'])? $_GET['search'] : '';
 
-    echo "<div class='linkTop'>";
-        if ($search != '') {
-            echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Query Builder/queries.php&search=$search'>".__($guid, 'Back to Search Results').'</a> | ';
-        }
-        echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Query Builder/queries_edit.php&search=$search&queryBuilderQueryID=$queryBuilderQueryID&sidebar=false'>".__m('Edit Query')."</a>" ;
-    echo '</div>';
-
     if (isset($_GET['return'])) {
         $illegals = isset($_GET['illegals'])? urldecode($_GET['illegals']) : '';
         returnProcess($guid, $_GET['return'], null, array('error3' => __('Your query contains the following illegal term(s), and so cannot be run:', 'Query Builder').' <b>'.substr($illegals, 0, -2).'</b>.'));
@@ -77,6 +70,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_run.
         } else {
             //Let's go!
             $values = $result->fetch();
+
+            echo "<div class='linkTop'>";
+            if ($search != '') {
+                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Query Builder/queries.php&search=$search'>".__($guid, 'Back to Search Results').'</a> | ';
+            }
+            if ($values['type'] != 'gibbonedu.com') {
+                echo "<a href='".$gibbon->session->get('absoluteURL')."/index.php?q=/modules/Query Builder/queries_edit.php&search=$search&queryBuilderQueryID=$queryBuilderQueryID&sidebar=false'>".__m('Edit Query')."</a>" ;
+            }
+            echo '</div>';
 
             echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
             echo '<tr>';

--- a/Query Builder/src/Forms/BindValues.php
+++ b/Query Builder/src/Forms/BindValues.php
@@ -1,0 +1,109 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\QueryBuilder\Forms;
+
+use Gibbon\Forms\Layout\Column;
+
+/**
+ * Bind Values
+ *
+ * @version v1.7.02
+ * @since   v1.7.02
+ */
+class BindValues extends Column
+{
+    protected $factory;
+    protected $values;
+
+    public function __construct($factory, $name, $values, $session)
+    {
+        $this->factory = $factory;
+        $this->values = $values;
+        $this->session = $session;
+
+        parent::__construct($factory, $name);
+    }
+
+    /**
+     * Gets the HTML output for this form element.
+     * @return  string
+     */
+    public function getOutput()
+    {
+        // BIND VALUES
+        $bindValues = json_decode($this->values['bindValues'] ?? '', true);
+        $types = [
+            __('Basic') => [
+                'varchar'        => __('Text'),
+                'number'         => __('Number'),
+                'yesno'          => __('Yes/No'),
+                'date'           => __('Date'),
+            ],
+            __('System') => [
+                'reportingCycle' => __('Reporting Cycle'),
+                'schoolYear'     => __('School Year'),
+                'term'           => __('Term'),
+            ],
+        ];
+
+        $missingValues = array_filter($bindValues ?? [], function ($bindValue) {
+            return strpos($this->values['query'], ':'.$bindValue['variable']) === false;
+        });
+
+        // Custom Block Template
+        $addBlockButton = $this->factory->createButton(__m('Add Variable'))->addClass('addBlock');
+
+        $blockTemplate = $this->factory->createTable()->setClass('blank');
+        $row = $blockTemplate->addRow();
+            $row->addTextField('name')
+                ->setClass('w-full m-0 title')
+                ->required()
+                ->placeholder(__m('Label Name'));
+
+        $col = $blockTemplate->addRow()->addColumn()->addClass('flex mt-1');
+            $col->addTextField('variable')
+                ->setClass('w-64')
+                ->required()
+                ->placeholder(__m('Variable Name'))
+                ->addValidation('Validate.Format', 'pattern: /^[A-Za-z0-9]+$/, failureMessage: "'.__m('Must be alphanumeric.').'"');
+            $col->addSelect('type')->fromArray($types)->setClass('w-full float-none ml-1')->required()->placeholder();
+
+        // Custom Blocks
+        $this->addLabel('bindValues', __m('Variables'));
+        $this->addContent(__m('You can optionally define named variables that a user can enter when running this query. Each variable name must be alphanumeric with no spaces or special symbols, and must be present in the query as :variableName'))->wrap('<span class="small emphasis">', '</span>');
+
+        if (!empty($missingValues)) {
+            $this->addAlert(__m('SQL Error! The following variable names were not found in your query: {variables}', ['variables' => implode(', ', array_column($missingValues, 'variable'))]), 'error');
+        }
+
+        $customBlocks = $this->addCustomBlocks('bindValues', $this->session)
+            ->fromTemplate($blockTemplate)
+            ->settings(array('inputNameStrategy' => 'object', 'addOnEvent' => 'click', 'sortable' => true))
+            ->placeholder(__m('Variables will be listed here...'))
+            ->addToolInput($addBlockButton);
+
+        // Add existing bindValues
+        foreach ($bindValues ?? [] as $index => $bindValue) {
+            $customBlocks->addBlock($index, $bindValue);
+        }
+
+        return parent::getOutput();
+    }
+}

--- a/Query Builder/version.php
+++ b/Query Builder/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '1.7.01';
+$moduleVersion = '1.7.02';


### PR DESCRIPTION
- Moves the variables code into a reusable class.
- Adds the variables section to the Add Query page.
- Tweaks the Edit Query link so it's not visible for gibbonedu.com queries.
- Tweaks the Run Query link so it's not visible for inactive queries.
- Enables bindValues for gibbonedu.com synced queries.

I've also added an example query to the gibbonedu.com database:
- "Activity Choices in Selected Year" starts with a versionFirst of v20.0.00 and predefined bindValues.
- "Activity Choices in Current Year" has a versionLast of v19.0.00, effectively replacing it with the new query in v20.

<img width="1123" alt="Screen Shot 2020-03-28 at 7 22 22 PM" src="https://user-images.githubusercontent.com/897700/77821978-84924e00-7129-11ea-9672-cb4b65c41936.png">