### PR TITLE
v1.13.00

### DIFF
--- a/Query Builder/CHANGEDB.php
+++ b/Query Builder/CHANGEDB.php
@@ -295,3 +295,10 @@ $sql[$count][1] = "";
 ++$count;
 $sql[$count][0] = '1.12.00';
 $sql[$count][1] = "";
+
+//v1.13.00
+++$count;
+$sql[$count][0] = '1.13.00';
+$sql[$count][1] = "
+ALTER TABLE `queryBuilderQuery` ADD `moduleName` VARCHAR(30) NULL DEFAULT NULL AFTER `category`, ADD `actionName` VARCHAR(50) NULL DEFAULT NULL AFTER `moduleName`;end
+";

--- a/Query Builder/CHANGELOG.txt
+++ b/Query Builder/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v1.13.00
+--------
+Enabled limiting access to queries based on use permissions
+
 v1.12.00
 --------
 Added SQL autocompletion to the editor

--- a/Query Builder/manifest.php
+++ b/Query Builder/manifest.php
@@ -25,7 +25,7 @@ $description = 'A module to provide SQL queries for pulling data out of Gibbon a
 $entryURL = 'queries.php';
 $type = 'Additional';
 $category = 'Admin';
-$version = '1.12.00';
+$version = '1.13.00';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org';
 

--- a/Query Builder/queries_add.php
+++ b/Query Builder/queries_add.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Module\QueryBuilder\Forms\BindValues;
+use Gibbon\Module\QueryBuilder\Domain\QueryGateway;
 
 // Module includes
 include __DIR__.'/moduleFunctions.php';
@@ -34,6 +35,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_add.
     echo '</div>';
 } else {
     //Proceed!
+    $queryGateway = $container->get(QueryGateway::class);
+    
     $returns = array();
     $editLink = '';
     if (isset($_GET['editID'])) {
@@ -85,6 +88,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_add.
         $row->addLabel('active', __('Active'));
         $row->addYesNo('active')->isRequired();
 
+    $values['moduleActionName'] = $values['moduleName'].':'.$values['actionName'];
+    $actions = $queryGateway->selectActionListByPerson($gibbon->session->get('gibbonPersonID'));
+    $row = $form->addRow();
+        $row->addLabel('moduleActionName', __('Limit Access'))->description(__('Only people with the selected permission can run this query.'));
+        $row->addSelect('moduleActionName')->fromResults($actions, 'groupBy')->placeholder();
+            
     $row = $form->addRow();
         $row->addLabel('description', __('Description'));
         $row->addTextArea('description')->setRows(8);

--- a/Query Builder/queries_addProcess.php
+++ b/Query Builder/queries_addProcess.php
@@ -34,10 +34,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_add.
     //Proceed!
     $queryGateway = $container->get(QueryGateway::class);
 
+    list($moduleName, $actionName) = !empty($_POST['moduleActionName']) ? explode(':', $_POST['moduleActionName']) : [null, null];
+
     $data = [
         'type'        => $_POST['type'] ?? '',
         'name'        => $_POST['name'] ?? '',
         'category'    => $_POST['category'] ?? '',
+        'moduleName'  => $moduleName ?? null,
+        'actionName'  => $actionName ?? null,
         'active'      => $_POST['active'] ?? 'Y',
         'description' => $_POST['description'] ?? '',
         'query'       => $_POST['query'] ?? '',

--- a/Query Builder/queries_duplicateProcess.php
+++ b/Query Builder/queries_duplicateProcess.php
@@ -62,6 +62,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_dupl
             $name = $_POST['name'];
             $type = $_POST['type'];
             $category = $row['category'];
+            $moduleName = $row['moduleName'];
+            $actionName = $row['actionName'];
             $active = $row['active'];
             $description = $row['description'];
             $query = $row['query'];
@@ -75,8 +77,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_dupl
             } else {
                 //Write to database
                 try {
-                    $data = array('type' => $type, 'name' => $name, 'category' => $category, 'active' => $active, 'description' => $description, 'query' => $query, 'bindValues' => $bindValues, 'gibbonPersonID' => $gibbonPersonID);
-                    $sql = 'INSERT INTO queryBuilderQuery SET type=:type, name=:name, category=:category, active=:active, description=:description, query=:query, bindValues=:bindValues, gibbonPersonID=:gibbonPersonID';
+                    $data = array('type' => $type, 'name' => $name, 'category' => $category, 'moduleName' => $moduleName, 'actionName' => $actionName, 'active' => $active, 'description' => $description, 'query' => $query, 'bindValues' => $bindValues, 'gibbonPersonID' => $gibbonPersonID);
+                    $sql = 'INSERT INTO queryBuilderQuery SET type=:type, name=:name, category=:category, moduleName=:moduleName, actionName=:actionName, active=:active, description=:description, query=:query, bindValues=:bindValues, gibbonPersonID=:gibbonPersonID';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/Query Builder/queries_editProcess.php
+++ b/Query Builder/queries_editProcess.php
@@ -34,9 +34,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Query Builder/queries_edit
     //Proceed!
     $queryGateway = $container->get(QueryGateway::class);
 
+    list($moduleName, $actionName) = !empty($_POST['moduleActionName']) ? explode(':', $_POST['moduleActionName']) : [null, null];
+
     $data = [
         'name'        => $_POST['name'] ?? '',
         'category'    => $_POST['category'] ?? '',
+        'moduleName'  => $moduleName ?? null,
+        'actionName'  => $actionName ?? null,
         'active'      => $_POST['active'] ?? 'Y',
         'description' => $_POST['description'] ?? '',
         'query'       => $_POST['query'] ?? '',

--- a/Query Builder/queries_gibboneducom_sync_ajax.php
+++ b/Query Builder/queries_gibboneducom_sync_ajax.php
@@ -66,7 +66,7 @@ if (count($queries) < 1) { // We have a problem, report it.
         }
 
         if ($insert) {
-            $data = array('queryID' => $query['queryID'], 'scope' => $query['scope'], 'name' => $query['name'], 'category' => $query['category'], 'description' => $query['description'], 'query' => $query['query'], 'bindValues' => $query['bindValues'] ?? '');
+            $data = array('queryID' => $query['queryID'], 'scope' => $query['scope'], 'name' => $query['name'], 'category' => $query['category'], 'description' => $query['description'], 'query' => $query['query'], 'bindValues' => $query['bindValues'] ?? '', 'moduleName' => $query['moduleName'] ?? null, 'actionName' => $query['actionName'] ?? null);
 
             $values = $queryGateway->selectBy(['queryID' => $query['queryID'], 'type' => 'gibbonedu.com'])->fetch();
             if (empty($values)) {

--- a/Query Builder/version.php
+++ b/Query Builder/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '1.12.00';
+$moduleVersion = '1.13.00';


### PR DESCRIPTION
This PR adds the ability to limit access to a query based on user's permissions. 

- When editing a query, users can select an action name to limit access, based on the permissions their roles have
  <img width="1120" alt="Screenshot 2020-11-05 at 2 01 50 PM" src="https://user-images.githubusercontent.com/897700/98211520-2231e380-1f7d-11eb-954c-e0add933b9bd.png">
- The action can be a specific grouped action, or a general action (eg: Manage Users (grouped) would allow both Manage Users_edit and Manage Users_editDelete)
- Filters the query list down by the queries a user had access to.
- Checks for access when editing, duplicating and running queries.
- Updates the value added queries to optionally specify the required actions when syncing.